### PR TITLE
[bugfix] Publish reasonable camera info when changing depth resolution.

### DIFF
--- a/src/nodelets/driver.h
+++ b/src/nodelets/driver.h
@@ -88,10 +88,10 @@ namespace openni_camera
 
       // Methods to get calibration parameters for the various cameras
       sensor_msgs::CameraInfoPtr getDefaultCameraInfo(int width, int height, double f) const;
-      sensor_msgs::CameraInfoPtr getRgbCameraInfo(ros::Time time) const;
-      sensor_msgs::CameraInfoPtr getIrCameraInfo(ros::Time time) const;
-      sensor_msgs::CameraInfoPtr getDepthCameraInfo(ros::Time time) const;
-      sensor_msgs::CameraInfoPtr getProjectorCameraInfo(ros::Time time) const;
+      sensor_msgs::CameraInfoPtr getRgbCameraInfo(int width, int height, ros::Time time) const;
+      sensor_msgs::CameraInfoPtr getIrCameraInfo(int width, int height, ros::Time time) const;
+      sensor_msgs::CameraInfoPtr getDepthCameraInfo(int width, int height, ros::Time time) const;
+      sensor_msgs::CameraInfoPtr getProjectorCameraInfo(int width, int height, ros::Time time) const;
 
       // published topics
       image_transport::CameraPublisher pub_rgb_;
@@ -121,7 +121,8 @@ namespace openni_camera
       double depth_ir_offset_y_;
       int z_offset_mm_;
 
-      /// @todo Prefer binning to changing width/height
+      // The desired image dimensions
+      // (might be different from what the driver gives us).
       unsigned image_width_;
       unsigned image_height_;
       unsigned depth_width_;


### PR DESCRIPTION
Fixes multiple problems:
- when depth registration was enabled, the camera info would always be for the rgb image, even when this has a different resolution
- when the kinect is calibrated, it would always publish the calibrated camera info even if resolutions don't match
- The principal point would be modified for the depth image based on a 640x480 image, no matter what the actual resolution was

Also, the logic in getDepthCameraInfo is a little less obscure now,; it's behaviour doesn't change.
