### PR TITLE
Depth scaling parameter

### DIFF
--- a/cfg/OpenNI.cfg
+++ b/cfg/OpenNI.cfg
@@ -30,6 +30,7 @@ gen.add("image_time_offset", double_t, 0, "image time offset in seconds", 0.0, -
 
 gen.add("depth_ir_offset_x", double_t, 0, "X offset between IR and depth images", 5.0, -10.0, 10.0)
 gen.add("depth_ir_offset_y", double_t, 0, "Y offset between IR and depth images", 4.0, -10.0, 10.0)
-gen.add("z_offset_mm", int_t, 0, "Z offset in mm", 0, -50, 50)
+gen.add("z_offset_mm", int_t, 0, "Z offset in mm", 0, -200, 200)
+gen.add("z_scaling", double_t, 0, "Scaling factor for depth values", 1.0, 0.5, 1.5)
 
 exit(gen.generate(PACKAGE, "OpenNI", "OpenNI"))

--- a/src/nodelets/driver.cpp
+++ b/src/nodelets/driver.cpp
@@ -547,12 +547,20 @@ void DriverNodelet::publishDepthImage(const openni_wrapper::DepthImage& depth, r
     ROS_ERROR_THROTTLE(1,e.what());
   }
 
+  if (fabs(z_scaling_ - 1.0) > 1e-6)
+  {
+    uint16_t* data = reinterpret_cast<uint16_t*>(&depth_msg->data[0]);
+    for (unsigned int i = 0; i < depth_msg->width * depth_msg->height; ++i)
+      if (data[i] != 0)
+	    data[i] = static_cast<uint16_t>(data[i] * z_scaling_);
+  }
+
   if (z_offset_mm_ != 0)
   {
     uint16_t* data = reinterpret_cast<uint16_t*>(&depth_msg->data[0]);
     for (unsigned int i = 0; i < depth_msg->width * depth_msg->height; ++i)
       if (data[i] != 0)
-	data[i] += z_offset_mm_;
+	    data[i] += z_offset_mm_;
   }
 
   if (registered)
@@ -721,6 +729,7 @@ void DriverNodelet::configCb(Config &config, uint32_t level)
   depth_ir_offset_x_ = config.depth_ir_offset_x;
   depth_ir_offset_y_ = config.depth_ir_offset_y;
   z_offset_mm_ = config.z_offset_mm;
+  z_scaling_ = config.z_scaling;
 
   // Based on the config options, try to set the depth/image mode
   // The device driver might decide to switch to a 'compatible mode',

--- a/src/nodelets/driver.h
+++ b/src/nodelets/driver.h
@@ -121,6 +121,7 @@ namespace openni_camera
       double depth_ir_offset_x_;
       double depth_ir_offset_y_;
       int z_offset_mm_;
+      double z_scaling_;
 
       // The desired image dimensions
       // (might be different from what the driver gives us).


### PR DESCRIPTION
This pull request adds a parameter for depth scaling, called "z_scaling". Together with the already present parameter "z_offset" it is possible to "correct" depth values using a linear function of type `y=ax+b`. Instead of full stereo-like calibration one can use these parameters to compensate for bad (factory-) focal length calibration of the IR camera.
The following graph shows depth measured using a checkerboard detection & solvePnP in the RGB image (mean z of all checkerboard corners) on the y axis and the corresponding depth of the depth image on the x axis together with a fitted line for one of our Asus XtionPRO Live cameras.

![Screenshot from 2013-04-15 16:08:53](https://f.cloud.github.com/assets/1481786/383688/98abe296-a621-11e2-9892-30e0126a4ca2.png)
