### PR TITLE
Fix compilation on OS X 10.9 (or anywhere else with a C++11 compiler)

### DIFF
--- a/src/openni_device.cpp
+++ b/src/openni_device.cpp
@@ -44,8 +44,8 @@
 #include <map>
 #include <vector>
 
-
-using namespace std;
+using std::vector;
+using std::map;
 using namespace boost;
 
 namespace openni_wrapper

--- a/src/openni_device_kinect.cpp
+++ b/src/openni_device_kinect.cpp
@@ -40,7 +40,6 @@
 #include <sstream>
 #include <boost/thread/mutex.hpp>
 
-using namespace std;
 using namespace boost;
 
 namespace openni_wrapper

--- a/src/openni_device_primesense.cpp
+++ b/src/openni_device_primesense.cpp
@@ -40,7 +40,6 @@
 #include <sstream>
 #include <boost/thread/mutex.hpp>
 
-using namespace std;
 using namespace boost;
 
 namespace openni_wrapper

--- a/src/openni_device_xtion.cpp
+++ b/src/openni_device_xtion.cpp
@@ -39,7 +39,6 @@
 #include <sstream>
 #include <boost/thread/mutex.hpp>
 
-using namespace std;
 using namespace boost;
 
 namespace openni_wrapper


### PR DESCRIPTION
unique_lock and friends is ambigious when using namespace std and boost, at
least with C++11.
