### PR TITLE
fix #28, properly parse device_id with only numbers

### DIFF
--- a/src/nodelets/driver.cpp
+++ b/src/nodelets/driver.cpp
@@ -239,8 +239,11 @@ void DriverNodelet::setupDevice ()
 
     try {
       string device_id;
-      if (!getPrivateNodeHandle().getParam("device_id", device_id))
+      int device_id_int;
+      if (!getPrivateNodeHandle().getParam("device_id", device_id) &&
+          !getPrivateNodeHandle().getParam("device_id", device_id_int))
       {
+        
         NODELET_WARN ("~device_id is not set! Using first device.");
         device_ = driver.getDeviceByIndex (0);
       }
@@ -260,6 +263,12 @@ void DriverNodelet::setupDevice ()
       }
       else
       {
+        if (device_id.empty()) // The ID passed contains only numbers
+        {  
+            std::stringstream ss;
+            ss << device_id_int;
+            device_id = ss.str();
+        }
         NODELET_INFO ("Searching for device with serial number = '%s'", device_id.c_str ());
         device_ = driver.getDeviceBySerialNumber (device_id);
       }


### PR DESCRIPTION
Indigo fix to #28  by checking wherever an string device_id
parameter is set or a device_id integer parameter is set. 
If both are missing it opens the first device found. If integer 
device_id is set then it parses it to string and load continues 
as if string version was set.
