### PR TITLE
Broken with `-Werror=format-security`

### DIFF
--- a/src/nodelets/driver.cpp
+++ b/src/nodelets/driver.cpp
@@ -520,7 +520,7 @@ void DriverNodelet::publishRgbImage(const openni_wrapper::Image& image, ros::Tim
   }
   catch ( OpenNIException e )
   {
-    ROS_ERROR_THROTTLE(1,e.what());
+    ROS_ERROR_THROTTLE(1,"%s",e.what());
   }
   
   pub_rgb_.publish(rgb_msg, getRgbCameraInfo(rgb_msg->width,rgb_msg->height,time));
@@ -546,7 +546,7 @@ void DriverNodelet::publishDepthImage(const openni_wrapper::DepthImage& depth, r
   }
   catch ( OpenNIException e )
   {
-    ROS_ERROR_THROTTLE(1,e.what());
+    ROS_ERROR_THROTTLE(1,"%s",e.what());
   }
 
   if (fabs(z_scaling_ - 1.0) > 1e-6)
@@ -602,7 +602,7 @@ void DriverNodelet::publishIrImage(const openni_wrapper::IRImage& ir, ros::Time 
   }
   catch ( OpenNIException e )
   {
-    ROS_ERROR_THROTTLE(1,e.what());
+    ROS_ERROR_THROTTLE(1,"%s",e.what());
   }
 
   pub_ir_.publish(ir_msg, getIrCameraInfo(ir.getWidth(), ir.getHeight(), time));


### PR DESCRIPTION
There are some places in `openni_camera` where supposedly "untrusted" format strings are used for IO. When `-Werror=format-security` is used, this yields errors in compilation.

This flag has been introduced to the default compilation flags for Fedora [1], and is preventing `openni_camera` from building on Fedora 21 [2].

For more info on `-Werror=format-security`, see [3]. I think there will be a straightforward fix for this, but I haven't had time to try anything. If someone has a sec to take a look, I'd appreciate it. Otherwise, I'll try to take a look in the next couple of weeks.

To the best of my knowledge, this is the only ROS package that is failing builds due to this flag. For a list of the locations in `openni_camera` where the errors occur, see the aforementioned build log in Jenkins.

Thanks,

--scott

[1] https://fedorahosted.org/fesco/ticket/1185
[2] http://csc.mcs.sdsmt.edu/jenkins/job/ros-indigo-openni-camera_binaryrpm_21_i386/13/consoleFull
[3] http://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html
