### PR TITLE
[fix] #18 "OpenNI Driver fails to set USB interface after update to 1.8.9"

### DIFF
--- a/include/openni_camera/openni_device.h
+++ b/include/openni_camera/openni_device.h
@@ -149,7 +149,7 @@ public:
   /** \brief returns the serial number for device.
    *  \attention This might be an empty string!!!
    */
-  const char* getSerialNumber () throw ();
+  const char* getSerialNumber () const throw ();
   /** \brief returns the connectionstring for current device, which has following format vendorID/productID\@BusID/DeviceID */
   const char* getConnectionString () const throw ();
 

--- a/include/openni_camera/openni_driver.h
+++ b/include/openni_camera/openni_driver.h
@@ -82,8 +82,6 @@ public:
   unsigned char  getBus (unsigned index) const throw ();
   unsigned char  getAddress (unsigned index) const throw ();
 
-  void getPrimesenseSerial(xn::NodeInfo info, char* buffer, unsigned buf_size) const throw ();
-
   void stopAll () throw (OpenNIException);
 
   static void getDeviceType (const std::string& connection_string, unsigned short& vendorId, unsigned short& productId);

--- a/src/openni_device.cpp
+++ b/src/openni_device.cpp
@@ -653,27 +653,9 @@ bool OpenNIDevice::unregisterIRCallback (const OpenNIDevice::CallbackHandle& cal
   return (ir_callback_.erase (callbackHandle) != 0);
 }
 
-const char* OpenNIDevice::getSerialNumber () throw ()
+const char* OpenNIDevice::getSerialNumber () const throw ()
 {
-    const char* openni_serial = device_node_info_.GetInstanceName ();
-    if (strlen(openni_serial)>0 && strcmp(openni_serial, "Device1")) {
-        return openni_serial;
-    } else {
-        char *primesense_serial = (char*)malloc(XN_MAX_NAME_LENGTH); // memleak
-        context_.CreateProductionTree(device_node_info_);
-        xn::Device device;
-
-        if(device_node_info_.GetInstance(device) != XN_STATUS_OK) {
-            THROW_OPENNI_EXCEPTION ("couldn't get device instance for reading serial no.");
-        }
-
-        xn::DeviceIdentificationCapability d = device.GetIdentificationCap();
-
-        d.GetSerialNumber(primesense_serial,XN_MAX_NAME_LENGTH);
-
-        device.Release();
-        return primesense_serial;
-    }
+  return device_node_info_.GetInstanceName ();
 }
 
 const char* OpenNIDevice::getConnectionString () const throw ()

--- a/src/openni_driver.cpp
+++ b/src/openni_driver.cpp
@@ -233,23 +233,7 @@ boost::shared_ptr<OpenNIDevice> OpenNIDriver::createVirtualDevice (const string&
 {
   return boost::shared_ptr<OpenNIDevice> (new DeviceONI (context_, path, repeat, stream));
 }
-
-void OpenNIDriver::getPrimesenseSerial(xn::NodeInfo info, char* buffer, unsigned buf_size) const throw () {
-
-        context_.CreateProductionTree(info);
-        xn::Device device;
-
-        if(info.GetInstance(device) != XN_STATUS_OK) {
-            THROW_OPENNI_EXCEPTION ("couldn't get device instance for reading serial no.");
-        }
-
-        xn::DeviceIdentificationCapability d = device.GetIdentificationCap();
-
-        d.GetSerialNumber(buffer,buf_size);
-
-        device.Release();
-}
-
+ 
 boost::shared_ptr<OpenNIDevice> OpenNIDriver::getDeviceByIndex (unsigned index) const throw (OpenNIException)
 {
   using namespace std;
@@ -410,19 +394,7 @@ OpenNIDriver::getDeviceInfos () throw ()
 const char* OpenNIDriver::getSerialNumber (unsigned index) const throw ()
 {
 #ifndef _WIN32
-
-    DeviceContext con = device_context_[index];
-    const char* openni_serial = con.device_node.GetInstanceName ();
-
-    if (strlen(openni_serial)>0 && strcmp(openni_serial, "Device1")) {
-        return openni_serial;
-    } else {
-        char *primesense_serial = (char*)malloc(XN_MAX_NAME_LENGTH); // memleak
-        getPrimesenseSerial(con.device_node, primesense_serial, XN_MAX_NAME_LENGTH);
-
-        return primesense_serial;
-    }
-
+  return device_context_[index].device_node.GetInstanceName ();
 #else
   return "";
 #endif

--- a/src/openni_driver.cpp
+++ b/src/openni_driver.cpp
@@ -362,12 +362,15 @@ OpenNIDriver::getDeviceInfos () throw ()
 
     unsigned nodeIdx = addressIt->second;
     xn::NodeInfo& current_node = device_context_[nodeIdx].device_node;
+    XnProductionNodeDescription& description = const_cast<XnProductionNodeDescription&>(current_node.GetDescription ());
 
     libusb_device_descriptor descriptor;
     result = libusb_get_device_descriptor (devices[devIdx], &descriptor);
 
     if (result < 0)
     {
+      strcpy (description.strVendor, "unknown");
+      strcpy (description.strName, "unknown");
       current_node.SetInstanceName ("");
     }
     else
@@ -376,11 +379,18 @@ OpenNIDriver::getDeviceInfos () throw ()
       result = libusb_open (device, &dev_handle);
       if (result < 0)
       {
+        strcpy (description.strVendor, "unknown");
+        strcpy (description.strName, "unknown");
         current_node.SetInstanceName ("");
       }
       else
       {
         unsigned char buffer[1024];
+        libusb_get_string_descriptor_ascii (dev_handle, descriptor.iManufacturer, buffer, 1024);
+        strcpy (description.strVendor, (char*)buffer);
+
+        libusb_get_string_descriptor_ascii (dev_handle, descriptor.iProduct, buffer, 1024);
+        strcpy (description.strName, (char*)buffer);
 
         int len = libusb_get_string_descriptor_ascii (dev_handle, descriptor.iSerialNumber, buffer, 1024);
         if (len > 4)


### PR DESCRIPTION
#18 is an years-old issue but according to https://github.com/ros-drivers/openni_camera/pull/48#issuecomment-296034398 it might be still a valid issue.
Can @ccckblaze (or either one of @robevans, @forouher, @andrew-ang, @georgebrindeiro or @dragonjack from #18) test with this branch on ROS Indigo that'll be great.