### PR TITLE
update to use non deprecated pluginlib macro

### DIFF
--- a/src/nodelets/driver.cpp
+++ b/src/nodelets/driver.cpp
@@ -949,4 +949,4 @@ void DriverNodelet::watchDog (const ros::TimerEvent& event)
 
 // Register as nodelet
 #include <pluginlib/class_list_macros.h>
-PLUGINLIB_DECLARE_CLASS (openni_camera, driver, openni_camera::DriverNodelet, nodelet::Nodelet);
+PLUGINLIB_EXPORT_CLASS(openni_camera::DriverNodelet, nodelet::Nodelet)


### PR DESCRIPTION
These macros, deprecated for now 8 years, will be removed in the next ROS release (ROS Melodic)

This change will allow the code to keep compiling on future ROS versions